### PR TITLE
NEVISACCESSAPP-5452: Always access local.properties from root project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 }
 
 ext.getConfig = { String name ->
-    File localPropertiesFile = project.file('local.properties')
+    File localPropertiesFile = project.rootProject.file('local.properties')
     if (localPropertiesFile?.exists()) {
         Properties localProperties = new Properties()
         localProperties.load(localPropertiesFile.newDataInputStream())


### PR DESCRIPTION
- This makes property retrieval possible from module level gradle scripts