### PR TITLE
NEVISACCESSAPP-6287: Require account to exist at transaction confirma…

### DIFF
--- a/app/src/main/java/ch/nevis/exampleapp/domain/interaction/AccountSelectorImpl.kt
+++ b/app/src/main/java/ch/nevis/exampleapp/domain/interaction/AccountSelectorImpl.kt
@@ -45,7 +45,7 @@ class AccountSelectorImpl(
             .sdk("Please select one of the received available accounts!")
         try {
             val accounts = validAccounts(context)
-            val transactionConfirmationData =
+            val transactionConfirmationData: ByteArray? =
                 context.transactionConfirmationData().orElse(null)
             when(accounts.size) {
                 0 -> throw BusinessException.accountsNotFound()
@@ -70,10 +70,10 @@ class AccountSelectorImpl(
                     navigationDispatcher.requestNavigation(
                         NavigationGraphDirections.actionGlobalSelectAccountFragment(
                             SelectAccountNavigationParameter(
-                                Operation.OUT_OF_BAND_AUTHENTICATION,
-                                accounts,
-                                handler,
-                                transactionConfirmationData?.decodeToString()
+                                operation = Operation.OUT_OF_BAND_AUTHENTICATION,
+                                accounts = accounts,
+                                accountSelectionHandler = handler,
+                                message = transactionConfirmationData?.decodeToString()
                             )
                         )
                     )

--- a/app/src/main/java/ch/nevis/exampleapp/ui/transactionConfirmation/TransactionConfirmationViewModel.kt
+++ b/app/src/main/java/ch/nevis/exampleapp/ui/transactionConfirmation/TransactionConfirmationViewModel.kt
@@ -42,7 +42,7 @@ class TransactionConfirmationViewModel @Inject constructor(
     /**
      * The previously selected account.
      */
-    private var account: Account? = null
+    private lateinit var account: Account
 
     /**
      * An instance of an [AccountSelectionHandler]. Transaction confirmation data received only in case an out-of-band authentication is started
@@ -61,7 +61,7 @@ class TransactionConfirmationViewModel @Inject constructor(
      * @param parameter The [TransactionConfirmationNavigationParameter] that was received by the owner [TransactionConfirmationFragment].
      */
     fun updateViewModel(parameter: TransactionConfirmationNavigationParameter) {
-        this.account = parameter.account
+        this.account = parameter.account ?: throw BusinessException.invalidState()
         this.accountSelectionHandler = parameter.accountSelectionHandler
 
         requestViewUpdate(TransactionConfirmationViewData(parameter.transactionConfirmationMessage))
@@ -72,7 +72,6 @@ class TransactionConfirmationViewModel @Inject constructor(
      */
     fun confirm() {
         try {
-            val account = this.account ?: throw BusinessException.invalidState()
             val accountSelectionHandler =
                 this.accountSelectionHandler ?: throw BusinessException.invalidState()
 

--- a/app/src/main/java/ch/nevis/exampleapp/ui/transactionConfirmation/parameter/TransactionConfirmationNavigationParameter.kt
+++ b/app/src/main/java/ch/nevis/exampleapp/ui/transactionConfirmation/parameter/TransactionConfirmationNavigationParameter.kt
@@ -6,7 +6,6 @@
 
 package ch.nevis.exampleapp.ui.transactionConfirmation.parameter
 
-import ch.nevis.exampleapp.domain.model.operation.Operation
 import ch.nevis.exampleapp.ui.base.model.NavigationParameter
 import ch.nevis.mobile.sdk.api.localdata.Account
 import ch.nevis.mobile.sdk.api.operation.selection.AccountSelectionHandler
@@ -46,7 +45,6 @@ data class TransactionConfirmationNavigationParameter(
      * An instance of an [AccountSelectionHandler]. Transaction confirmation data received only in case an out-of-band authentication is started
      * and we navigate to Transaction Confirmation view to ask the user to confirm or deny the operation based on the transaction confirmation data
      * before we continue the operation with account selection.
-     * [TransactionConfirmationNavigationParameter.operation] will always be [Operation.OUT_OF_BAND_AUTHENTICATION]
      */
     @IgnoredOnParcel
     val accountSelectionHandler: AccountSelectionHandler? = null


### PR DESCRIPTION
…tion and other fixes

- Make account a lateinit non-optional property in TransactionConfirmationViewModel as now that Account Selection always comes before Transaction Confirmation, it should always be determined at this point
- As the property in TransactionConfirmationNavigationParameter need to be null to be ignored on parcelable (when deserialized, it needs a default value and we cannot really define a better default value than null), a check is necessary in the updateViewModel method, but it just moves this check earlier in the flow (previously a similar check was in confirm)
- Remove the mention of the now deleted operation property in TransactionConfirmationNavigationParameter