### PR TITLE
NEVISACCESSAPP-5829: Better configure ktlint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,6 @@ insert_final_newline = true
 [*.{kt,kts}]
 ktlint_code_style = android_studio
 max_line_length = 140
+
+# Force IntelliJ IDEA to use strict alphabetical layout of ktlint
+ij_kotlin_imports_layout = *,^

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -75,6 +75,16 @@ android {
     }
 }
 
+ktlint {
+    android.set(true)
+    ignoreFailures.set(false)
+    outputToConsole.set(true)
+    reporters {
+        reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.PLAIN)
+        reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.HTML)
+    }
+}
+
 dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,9 +90,6 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
     implementation(libs.androidx.constraintlayout)
-    testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.test.espresso.core)
 
     // Barcode Scanning, to scan QR codes
     implementation(libs.mlkit.barcode.scanning)
@@ -122,6 +119,10 @@ dependencies {
     // Retrofit (HTTP requests)
     implementation(libs.retrofit)
     implementation(libs.retrofit.converter.json)
+
+    testImplementation(libs.junit)
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.test.espresso.core)
 }
 
 dokka {


### PR DESCRIPTION
- Configure the ktlint Gradle plugin to report errors in a nicer way (output a formatted HTML too and also to console with navigable links to code)
- Force IntelliJ IDEA to use strict alphabetical layout of ktlint to avoid optimize imports to clash with ktlint